### PR TITLE
feat: disable DockerHub upload except for tags

### DIFF
--- a/.github/workflows/fedimint-ui-docker.yml
+++ b/.github/workflows/fedimint-ui-docker.yml
@@ -25,14 +25,13 @@ jobs:
           images: |
             fedimintui/fedimint-ui
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=sha
 
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@v2
         with:
           username: fedimintui
@@ -42,17 +41,17 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: Dockerfile
-          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Checkout repository content
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/checkout@v4
 
       # This workflow requires the repository content to be locally available to read the README
       - name: Update the Docker Hub description
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: peter-evans/dockerhub-description@v3
         with:
           username: fedimintui


### PR DESCRIPTION
Our dockerhub is far too noisy. [see here](https://hub.docker.com/r/fedimintui/fedimint-ui/tags)


Let's only upload tagged commits/releases to dockerhub. 


cc @tsmith123 

