### PR TITLE
Pass url as query string param

### DIFF
--- a/apps/router/src/hooks/custom/useQuery.tsx
+++ b/apps/router/src/hooks/custom/useQuery.tsx
@@ -1,0 +1,10 @@
+// from react-router-dom examples
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const useQuery = () => {
+  const { search } = useLocation();
+
+  // return () => new URLSearchParams(search);
+  return useMemo(() => new URLSearchParams(search), [search]);
+};

--- a/apps/router/src/hooks/custom/useQuery.tsx
+++ b/apps/router/src/hooks/custom/useQuery.tsx
@@ -1,10 +1,9 @@
-// from react-router-dom examples
+// taken from react-router-dom examples
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export const useQuery = () => {
   const { search } = useLocation();
 
-  // return () => new URLSearchParams(search);
   return useMemo(() => new URLSearchParams(search), [search]);
 };

--- a/apps/router/src/hooks/index.tsx
+++ b/apps/router/src/hooks/index.tsx
@@ -63,3 +63,4 @@ export * from './guardian/useGuardian';
 export * from './guardian/useGuardianSetup';
 export * from './gateway/useGateway';
 export * from './custom/useTrimmedInput';
+export * from './custom/useQuery';

--- a/apps/router/src/pages/Home/Home.test.tsx
+++ b/apps/router/src/pages/Home/Home.test.tsx
@@ -11,8 +11,10 @@ import HomePage from './Home';
 
 // Mock AppContext
 const mockedUseAppContext = jest.fn();
+const mockedUseQuery = jest.fn();
 jest.mock('../../hooks', () => ({
   useAppContext: () => mockedUseAppContext(),
+  useQuery: () => mockedUseQuery(),
 }));
 
 // Mock sha256Hash
@@ -22,20 +24,24 @@ jest.mock('@fedimint/utils', () => ({
 }));
 
 describe('pages/Home', () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    mockedUseAppContext.mockImplementation(() => ({
+      service: null,
+      dispatch: mockDispatch,
+    }));
+
+    mockedUseQuery.mockReturnValue({
+      get: jest.fn(),
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   describe('When a user clicks the connect button with an empty input value', () => {
-    const mockDispatch = jest.fn();
-
-    beforeEach(() => {
-      mockedUseAppContext.mockImplementation(() => ({
-        service: null,
-        dispatch: mockDispatch,
-      }));
-    });
-
     it('should not call dispatch', async () => {
       render(<HomePage />);
 
@@ -52,15 +58,6 @@ describe('pages/Home', () => {
 
   // We don't support gateway urls at this time so check for this
   describe('When a user clicks the connect button with a gateway url input value', () => {
-    const mockDispatch = jest.fn();
-
-    beforeEach(() => {
-      mockedUseAppContext.mockImplementation(() => ({
-        service: null,
-        dispatch: mockDispatch,
-      }));
-    });
-
     it('should not call dispatch', async () => {
       render(<HomePage />);
 
@@ -82,15 +79,6 @@ describe('pages/Home', () => {
   });
 
   describe('When a user clicks the connect button with a guardian url input value', () => {
-    const mockDispatch = jest.fn();
-
-    beforeEach(() => {
-      mockedUseAppContext.mockImplementation(() => ({
-        service: null,
-        dispatch: mockDispatch,
-      }));
-    });
-
     it('should call dispatch', async () => {
       render(<HomePage />);
 
@@ -112,13 +100,6 @@ describe('pages/Home', () => {
   });
 
   describe('When there is no service in LocalStorage', () => {
-    beforeEach(() => {
-      mockedUseAppContext.mockImplementation(() => ({
-        service: null,
-        dispatch: jest.fn(),
-      }));
-    });
-
     it('should render an input without a value', () => {
       render(<HomePage />);
       const input = screen.getByPlaceholderText('Guardian URL');
@@ -167,6 +148,20 @@ describe('pages/Home', () => {
       const url = screen.getByDisplayValue(
         'https://gatewayd-1234.test.app:8175'
       );
+      expect(url).toBeInTheDocument();
+    });
+  });
+
+  describe('When a url is passed as a query param', () => {
+    beforeEach(() => {
+      mockedUseQuery.mockReturnValue({
+        get: jest.fn().mockReturnValue('wss://guardian-url.test.com:8174'),
+      });
+    });
+
+    it('should set query param value in input box', () => {
+      render(<HomePage />);
+      const url = screen.getByDisplayValue('wss://guardian-url.test.com:8174');
       expect(url).toBeInTheDocument();
     });
   });

--- a/apps/router/src/pages/Home/Home.tsx
+++ b/apps/router/src/pages/Home/Home.tsx
@@ -32,9 +32,6 @@ const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const query = useQuery();
 
-  // console.log('HIT', query);
-  // console.log('HIT2', query.get(''));
-
   const { dispatch, service } = useAppContext();
 
   const [serviceUrl, setServiceUrl] = useState<string>('');

--- a/apps/router/src/pages/Home/Home.tsx
+++ b/apps/router/src/pages/Home/Home.tsx
@@ -21,6 +21,7 @@ import { FaDiscord, FaGithub } from 'react-icons/fa';
 import { FiX } from 'react-icons/fi';
 import { APP_ACTION_TYPE } from '../../context/AppContext';
 import { useAppContext } from '../../hooks';
+import { useQuery } from '../../hooks';
 import HeroSvg from '../../images/hero-1.svg';
 import { getServiceType } from '../../helpers/service';
 import { LATEST_RELEASE_TAG } from '../../constants';
@@ -29,6 +30,11 @@ import { Logo } from '../../components/Logo';
 const HomePage: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const query = useQuery();
+
+  // console.log('HIT', query);
+  // console.log('HIT2', query.get(''));
+
   const { dispatch, service } = useAppContext();
 
   const [serviceUrl, setServiceUrl] = useState<string>('');
@@ -38,11 +44,12 @@ const HomePage: React.FC = () => {
     setIsGateway(false);
   }, [serviceUrl]);
 
+  // If url query param provided then set this in input
+  // as priority, otherwise fallback to url in state and then empty string
   useEffect(() => {
-    if (service?.config) {
-      setServiceUrl(service.config.baseUrl);
-    }
-  }, [service]);
+    const url = query.get('url') || service?.config.baseUrl || '';
+    setServiceUrl(url);
+  }, [query, service]);
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const url = e.target.value;


### PR DESCRIPTION
Fixes #579 

This PR allows a user to pass a `url` query string param for a guardian/gateway when loading the UI. This string value will be added to the input box automatically.

**Note:** whilst we could connect automatically this would potentially cause a few issues such as if a user clicked back in the browser after connecting it would then connect them again. I prefer asking the user to click the connect button because this means they will follow the same flow as those who don't provide a query string param meaning we can reuse the same logic.

**Example**
```
https://fedimint-ui.com/?url=wss://btcpp-11.cypheru.net/ws/
```

![Screenshot 2025-02-19 at 13 25 04](https://github.com/user-attachments/assets/f64e1a9e-db45-4d59-a950-d72fb894c598)
