### PR TITLE
Improve Guardian Responsiveness

### DIFF
--- a/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
+++ b/apps/router/src/guardian-ui/admin/FederationAdmin.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Flex, Skeleton, Text } from '@chakra-ui/react';
+import { Box, Flex, Skeleton, Text } from '@chakra-ui/react';
 import {
   ClientConfig,
   SignedApiAnnouncement,
@@ -69,62 +69,68 @@ export const FederationAdmin: React.FC = () => {
   }, [config, status, signedApiAnnouncements]);
 
   return (
-    <Flex gap='32px' flexDirection='row'>
-      <Flex gap={4} flexDirection='column' w='100%'>
-        {config ? (
-          <Flex gap={6} justifyContent='space-between' alignItems='center'>
-            <Flex flexDirection='column' gap={3}>
-              <Flex alignItems='baseline'>
-                <Text
-                  fontSize='sm'
-                  color='gray.500'
-                  textTransform='uppercase'
-                  letterSpacing='wide'
-                  width='150px'
-                >
-                  {t('common.federation-name')}
-                </Text>
-                <Text fontSize='lg' color='gray.700' fontWeight='medium'>
-                  {config.global.meta.federation_name}
-                </Text>
-              </Flex>
-              <Flex alignItems='baseline'>
-                <Text
-                  fontSize='sm'
-                  color='gray.500'
-                  textTransform='uppercase'
-                  letterSpacing='wide'
-                  width='150px'
-                >
-                  {t('common.guardian-name')}
-                </Text>
-                <Text fontSize='lg' color='gray.700' fontWeight='medium'>
-                  {ourPeer?.name}
-                </Text>
-              </Flex>
+    <Flex flexDirection='column' gap='3'>
+      {config ? (
+        <Flex
+          alignItems={{ md: 'center' }}
+          flexDirection={{ base: 'column', md: 'row' }}
+          justifyContent='space-between'
+          gap='1'
+          mb='2'
+        >
+          <Flex flexDirection='column' gap='1' mb={{ base: 1, md: 0 }} flex='3'>
+            <Flex alignItems='center'>
+              <Text
+                fontSize='sm'
+                color='gray.500'
+                textTransform='uppercase'
+                letterSpacing='wide'
+                width='150px'
+              >
+                {t('common.federation-name')}
+              </Text>
+              <Text fontSize='md' color='gray.700' fontWeight='semibold'>
+                {config?.global.meta.federation_name}
+              </Text>
             </Flex>
-            <InviteCode inviteCode={inviteCode} />
+            <Flex alignItems='center'>
+              <Text
+                fontSize='sm'
+                color='gray.500'
+                textTransform='uppercase'
+                letterSpacing='wide'
+                width='150px'
+              >
+                {t('common.guardian-name')}
+              </Text>
+              <Text fontSize='md' color='gray.700' fontWeight='semibold'>
+                {ourPeer?.name}
+              </Text>
+            </Flex>
           </Flex>
-        ) : (
-          <Skeleton height='120px' width='100%' />
-        )}
 
-        {ourPeer && (
-          <FederationTabsCard
-            config={config}
-            ourPeer={ourPeer}
-            signedApiAnnouncements={signedApiAnnouncements}
-            latestSession={latestSession}
-            status={status}
-          />
-        )}
-        <DangerZone
-          inviteCode={inviteCode}
+          <Box flex='2'>
+            <InviteCode inviteCode={inviteCode} />
+          </Box>
+        </Flex>
+      ) : (
+        <Skeleton height='120px' width='100%' />
+      )}
+      {ourPeer && (
+        <FederationTabsCard
+          config={config}
           ourPeer={ourPeer}
-          latestSession={latestSession}
           signedApiAnnouncements={signedApiAnnouncements}
+          latestSession={latestSession}
+          status={status}
         />
-      </Flex>
+      )}
+      <DangerZone
+        inviteCode={inviteCode}
+        ourPeer={ourPeer}
+        latestSession={latestSession}
+        signedApiAnnouncements={signedApiAnnouncements}
+      />
     </Flex>
   );
 };

--- a/apps/router/src/guardian-ui/components/dashboard/admin/InviteCode.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/admin/InviteCode.tsx
@@ -33,7 +33,7 @@ export const InviteCode: React.FC<InviteCodeProps> = ({ inviteCode }) => {
   const handleClose = () => setIsOpen(false);
 
   return (
-    <Box bg='blue.50' p={2} borderRadius='md' maxWidth='40%' minWidth='240px'>
+    <Box bg='blue.50' p={2} borderRadius='md' width='100%'>
       <Text
         mb='6px'
         fontSize='14px'


### PR DESCRIPTION
The layout of the Guardian admin page quickly degrades when the viewport is narrowed. This PR is the first in a series of UI updates to improve the responsiveness.

**Old Mobile View**
![Screenshot 2025-02-27 at 20 16 26](https://github.com/user-attachments/assets/b16704ae-1ce8-40fb-a0da-ddba5de413d9)

**New Mobile View**
![Screenshot 2025-02-27 at 20 16 37](https://github.com/user-attachments/assets/5f4440dd-df77-4106-8ea7-5312994a6b4c)

**Old Desktop View**
![Screenshot 2025-02-27 at 20 17 06](https://github.com/user-attachments/assets/00fcf912-fba3-4dc5-9882-5bcc7ebc197d)

**New Desktop View**
![Screenshot 2025-02-27 at 20 16 57](https://github.com/user-attachments/assets/6fda6225-2f4f-4e74-a051-d0a7be6128a0)