### PR TITLE
Improve Placeholder On Homepage

### DIFF
--- a/apps/router/src/pages/Home/Home.test.tsx
+++ b/apps/router/src/pages/Home/Home.test.tsx
@@ -57,7 +57,7 @@ describe('pages/Home', () => {
       render(<HomePage />);
 
       const input = screen.getByPlaceholderText(
-        'e.g. wss://fedimintd-url.com:8174'
+        'e.g. wss://fedimintd-url.com'
       ) as HTMLInputElement;
 
       await act(async () => {
@@ -78,7 +78,7 @@ describe('pages/Home', () => {
       render(<HomePage />);
 
       const input = screen.getByPlaceholderText(
-        'e.g. wss://fedimintd-url.com:8174'
+        'e.g. wss://fedimintd-url.com'
       ) as HTMLInputElement;
 
       await act(async () => {
@@ -97,9 +97,7 @@ describe('pages/Home', () => {
   describe('When there is no service in LocalStorage', () => {
     it('should render an input without a value', () => {
       render(<HomePage />);
-      const input = screen.getByPlaceholderText(
-        'e.g. wss://fedimintd-url.com:8174'
-      );
+      const input = screen.getByPlaceholderText('e.g. wss://fedimintd-url.com');
 
       expect(input).toBeInTheDocument();
     });

--- a/apps/router/src/pages/Home/Home.test.tsx
+++ b/apps/router/src/pages/Home/Home.test.tsx
@@ -57,7 +57,7 @@ describe('pages/Home', () => {
       render(<HomePage />);
 
       const input = screen.getByPlaceholderText(
-        'home.guardian-url'
+        'e.g. wss://fedimintd-url.com:8174'
       ) as HTMLInputElement;
 
       await act(async () => {
@@ -78,7 +78,7 @@ describe('pages/Home', () => {
       render(<HomePage />);
 
       const input = screen.getByPlaceholderText(
-        'home.guardian-url'
+        'e.g. wss://fedimintd-url.com:8174'
       ) as HTMLInputElement;
 
       await act(async () => {
@@ -97,7 +97,9 @@ describe('pages/Home', () => {
   describe('When there is no service in LocalStorage', () => {
     it('should render an input without a value', () => {
       render(<HomePage />);
-      const input = screen.getByPlaceholderText('home.guardian-url');
+      const input = screen.getByPlaceholderText(
+        'e.g. wss://fedimintd-url.com:8174'
+      );
 
       expect(input).toBeInTheDocument();
     });

--- a/apps/router/src/pages/Home/Home.tsx
+++ b/apps/router/src/pages/Home/Home.tsx
@@ -155,7 +155,7 @@ const HomePage: React.FC = () => {
                 name='url'
                 autoFocus
                 variant='outline'
-                placeholder={t('home.guardian-url')}
+                placeholder='e.g. wss://fedimintd-url.com:8174'
                 value={serviceUrl}
                 onChange={handleOnChange}
                 onKeyDown={handleOnKeyDown}

--- a/apps/router/src/pages/Home/Home.tsx
+++ b/apps/router/src/pages/Home/Home.tsx
@@ -155,7 +155,7 @@ const HomePage: React.FC = () => {
                 name='url'
                 autoFocus
                 variant='outline'
-                placeholder='e.g. wss://fedimintd-url.com:8174'
+                placeholder='e.g. wss://fedimintd-url.com'
                 value={serviceUrl}
                 onChange={handleOnChange}
                 onKeyDown={handleOnKeyDown}


### PR DESCRIPTION
After some feedback in #628 this PR adds an example url as the placeholder on the Homepage to indicate it's a websocket url that's required.

![Screenshot 2025-03-03 at 10 59 23](https://github.com/user-attachments/assets/231ea380-a8a3-44b8-8191-50a22d1ff0a2)
