### PR TITLE
Feat: Add toggle for privacy check for ValidateIcon 

### DIFF
--- a/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/IconPreview.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/IconPreview.tsx
@@ -3,34 +3,42 @@ import { Box, Image } from '@chakra-ui/react';
 
 interface IconPreviewProps {
   imageUrl: string;
+  validationState?: { valid: boolean; error: string };
 }
 
-export const IconPreview: React.FC<IconPreviewProps> = ({ imageUrl }) => (
-  <Box
-    width='40px'
-    height='40px'
-    borderRadius='md'
-    overflow='hidden'
-    bg='gray.100'
-    display='flex'
-    alignItems='center'
-    justifyContent='center'
-    boxShadow='sm'
-    flexShrink={0}
-  >
-    {imageUrl ? (
-      <Image
-        src={imageUrl}
-        alt='Icon'
-        objectFit='cover'
-        width='100%'
-        height='100%'
-        fallback={<Box>?</Box>}
-      />
-    ) : (
-      <Box fontSize='md' fontWeight='bold' color='gray.400'>
-        ?
-      </Box>
-    )}
-  </Box>
-);
+export const IconPreview: React.FC<IconPreviewProps> = ({
+  imageUrl,
+  validationState,
+}) => {
+  const isValid = validationState === undefined ? true : validationState.valid;
+
+  return (
+    <Box
+      width='40px'
+      height='40px'
+      borderRadius='md'
+      overflow='hidden'
+      bg='gray.100'
+      display='flex'
+      alignItems='center'
+      justifyContent='center'
+      boxShadow='sm'
+      flexShrink={0}
+    >
+      {imageUrl && isValid ? (
+        <Image
+          src={imageUrl}
+          alt='Icon'
+          objectFit='cover'
+          width='100%'
+          height='100%'
+          fallback={<Box>?</Box>}
+        />
+      ) : (
+        <Box fontSize='md' fontWeight='bold' color='gray.400'>
+          ?
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/apps/router/src/guardian-ui/utils/debounce.ts
+++ b/apps/router/src/guardian-ui/utils/debounce.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
Closes #605 

Adds privacy feature to control when image URLs are validated and previewed in the custom metadata fields and sites input components. It adds a toggle switch that allows users to disable automatic external requests for image validation when privacy is a concern.

[Screencast from 2025-03-09 01-54-58.webm](https://github.com/user-attachments/assets/3283cd5a-dcca-46b7-92af-7a56366f3a27)

