### PR TITLE
Handle New Bitcoin Status Response

### DIFF
--- a/apps/router/src/api/GuardianApi.ts
+++ b/apps/router/src/api/GuardianApi.ts
@@ -2,6 +2,7 @@ import { JsonRpcError, JsonRpcWebsocket } from 'jsonrpc-client-websocket';
 import {
   AuditSummary,
   BitcoinRpcConnectionStatus,
+  BitcoinRpcConnectionStatusProgress,
   ClientConfig,
   ConfigGenParams,
   ConsensusState,
@@ -113,8 +114,19 @@ export class GuardianApi {
     return this.call(SharedRpc.status);
   };
 
-  checkBitcoinStatus = (): Promise<BitcoinRpcConnectionStatus> => {
-    return this.call(SharedRpc.checkBitcoinStatus);
+  // This handles both 0.5 and 0.6 shaped responses and returns just 0.5 response (string)
+  checkBitcoinStatus = async (): Promise<BitcoinRpcConnectionStatus> => {
+    const result:
+      | BitcoinRpcConnectionStatus
+      | BitcoinRpcConnectionStatusProgress = await this.call(
+      SharedRpc.checkBitcoinStatus
+    );
+
+    if (typeof result === 'object') {
+      return result?.sync_percentage > 0.9999 ? 'Synced' : 'NotSynced';
+    }
+
+    return result;
   };
 
   /*** Setup RPC methods ***/

--- a/packages/types/src/bitcoin.ts
+++ b/packages/types/src/bitcoin.ts
@@ -31,4 +31,12 @@ export class Bip21Uri {
   }
 }
 
+// 0.5 check_bitcoin_status response shape
 export type BitcoinRpcConnectionStatus = 'Synced' | string;
+
+// 0.6 check_bitcoin_statusresponse shape
+export type BitcoinRpcConnectionStatusProgress = {
+  chain_top_block_height: number;
+  chain_top_block_time: number;
+  sync_percentage: number;
+};


### PR DESCRIPTION
Fedimint version 0.6 returns a different response shape from the `check_bitcoin_status` endpoint and this makes it impossible to start the guardian ceremony. This PR handles responses from versions 0.5 and 0.6.