### PR TITLE
refactor: use typed useTheme from @fedimint/ui

### DIFF
--- a/apps/router/src/components/Footer.tsx
+++ b/apps/router/src/components/Footer.tsx
@@ -1,11 +1,10 @@
 import React, { ReactElement } from 'react';
-import { Flex, useTheme, Link, Icon } from '@chakra-ui/react';
+import { Flex, Link, Icon } from '@chakra-ui/react';
 import { FaDiscord, FaGithub } from 'react-icons/fa';
 import { LATEST_RELEASE_TAG } from '../constants';
+import { theme } from '../../../../packages/ui/src/theme';
 
 export const Footer = () => {
-  const theme = useTheme();
-
   interface CustomLinkProps {
     href: string;
     children: string | ReactElement;

--- a/apps/router/src/gateway-ui/components/ConnectFederationModal.tsx
+++ b/apps/router/src/gateway-ui/components/ConnectFederationModal.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   Stack,
   Text,
-  useTheme,
   Textarea,
   Modal,
   ModalBody,
@@ -17,6 +16,7 @@ import { GatewayInfo } from '@fedimint/types';
 import { useTranslation } from '@fedimint/utils';
 import { useGatewayApi, useGatewayContext, useGatewayInfo } from '../../hooks';
 import { GATEWAY_APP_ACTION_TYPE } from '../../types/gateway';
+import { theme } from '../../../../../packages/ui/src/theme';
 
 export type ConnectFederationModalProps = {
   isOpen: boolean;
@@ -35,7 +35,6 @@ export const ConnectFederationModal = React.memo(
     const [connectInfo, setConnectInfo] = useState<string>('');
     const [errorMsg, setErrorMsg] = useState<string>('');
     const [loading, setLoading] = useState(false);
-    const theme = useTheme();
 
     const handleInputString = (
       event: React.ChangeEvent<HTMLTextAreaElement>

--- a/apps/router/src/gateway-ui/components/ErrorMessage.tsx
+++ b/apps/router/src/gateway-ui/components/ErrorMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Flex, Heading, Text, useTheme } from '@chakra-ui/react';
+import { Flex, Heading, Text } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
+import { theme } from '../../../../../packages/ui/src/theme';
 
 interface ErrorMessageProps {
   error: string;
@@ -8,7 +9,6 @@ interface ErrorMessageProps {
 
 export const ErrorMessage: React.FC<ErrorMessageProps> = ({ error }) => {
   const { t } = useTranslation();
-  const theme = useTheme();
 
   return (
     <Flex

--- a/apps/router/src/gateway-ui/components/HeaderWithUnitSelector.tsx
+++ b/apps/router/src/gateway-ui/components/HeaderWithUnitSelector.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Flex, Heading, Tabs, TabList, Tab, useTheme } from '@chakra-ui/react';
+import { Flex, Heading, Tabs, TabList, Tab } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { useGatewayContext } from '../../hooks';
 import { GATEWAY_APP_ACTION_TYPE } from '../../types/gateway';
 import { UNIT_OPTIONS } from '../../types';
+import { theme } from '../../../../../packages/ui/src/theme';
 
 export const HeaderWithUnitSelector: React.FC = () => {
   const { dispatch } = useGatewayContext();
-  const theme = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/apps/router/src/gateway-ui/components/Loading.tsx
+++ b/apps/router/src/gateway-ui/components/Loading.tsx
@@ -3,12 +3,11 @@ import {
   Flex,
   CircularProgress,
   CircularProgressLabel,
-  useTheme,
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
+import { theme } from '../../../../../packages/ui/src/theme';
 
 export const Loading: React.FC = () => {
-  const theme = useTheme();
   const { t } = useTranslation();
 
   return (

--- a/apps/router/src/gateway-ui/components/federations/ConnectFederation.tsx
+++ b/apps/router/src/gateway-ui/components/federations/ConnectFederation.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   Stack,
   Text,
-  useTheme,
   Flex,
   Textarea,
   Modal,
@@ -19,6 +18,7 @@ import {
 import { FederationInfo } from '@fedimint/types';
 import { useTranslation } from '@fedimint/utils';
 import { useGatewayApi } from '../../../hooks';
+import { theme } from '../../../../../../packages/ui/src/theme';
 
 export interface ConnectFedModalProps {
   isOpen: boolean;
@@ -29,7 +29,6 @@ export const ConnectFedModal: FC<ConnectFedModalProps> = ({
   isOpen,
   onClose,
 }) => {
-  const theme = useTheme();
   const { t } = useTranslation();
 
   return (
@@ -88,7 +87,6 @@ export const ConnectFederation = React.memo(function ConnectFederation({
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [connectInfo, setConnectInfo] = useState<string>('');
   const [loading, setLoading] = useState(false);
-  const theme = useTheme();
 
   const handleInputString = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     event.preventDefault();

--- a/apps/router/src/gateway-ui/components/federations/FederationsTable.tsx
+++ b/apps/router/src/gateway-ui/components/federations/FederationsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, Flex, Link, useTheme, Button } from '@chakra-ui/react';
+import { Text, Flex, Link, Button } from '@chakra-ui/react';
 import { MSats } from '@fedimint/types';
 import { useTranslation, formatEllipsized, formatValue } from '@fedimint/utils';
 import { Table, TableColumn, TableRow } from '@fedimint/ui';
@@ -11,10 +11,10 @@ import {
   WalletModalType,
 } from '../../../types/gateway';
 import { useGatewayContext } from '../../../hooks';
+import { theme } from '../../../../../../packages/ui/src/theme';
 
 export const FederationsTable: React.FC = () => {
   const { t } = useTranslation();
-  const theme = useTheme();
   const { state, dispatch } = useGatewayContext();
   const columns: TableColumn<'name' | 'id' | 'balance' | 'actions'>[] = [
     { key: 'name', heading: t('federation-card.name') },

--- a/apps/router/src/guardian-ui/components/dashboard/admin/InviteCode.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/admin/InviteCode.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Icon,
   Text,
-  useTheme,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -18,6 +17,7 @@ import { useTranslation } from '@fedimint/utils';
 import CopyIcon from '../../../assets/svgs/copy.svg?react';
 import QrIcon from '../../../assets/svgs/qr.svg?react';
 import { QRCodeSVG } from 'qrcode.react';
+import { theme } from '../../../../../../../packages/ui/src/theme';
 
 const QR_CODE_SIZE = 256;
 
@@ -26,7 +26,6 @@ interface InviteCodeProps {
 }
 
 export const InviteCode: React.FC<InviteCodeProps> = ({ inviteCode }) => {
-  const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = () => setIsOpen(true);

--- a/apps/router/src/guardian-ui/components/dashboard/danger/DownloadBackup.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/DownloadBackup.tsx
@@ -9,14 +9,13 @@ import {
   ModalBody,
   Text,
   Flex,
-  useTheme,
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { hexToBlob } from '../../../utils/api';
 import { useGuardianAdminApi } from '../../../../hooks';
+import { theme } from '../../../../../../../packages/ui/src/theme';
 
 export const DownloadBackup: React.FC = () => {
-  const theme = useTheme();
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
   const api = useGuardianAdminApi();
   const { t } = useTranslation();

--- a/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/GuardianAuthenticationCode.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   Text,
-  useTheme,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -13,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { QRCodeSVG } from 'qrcode.react';
+import { theme } from '../../../../../../../packages/ui/src/theme';
 
 const QR_CODE_SIZE = 256;
 const FEDIMINT_GUARDIAN_PREFIX = 'fedimint:guardian:';
@@ -32,7 +32,6 @@ interface GuardianAuthenticationCodeProps {
 export const GuardianAuthenticationCode: React.FC<
   GuardianAuthenticationCodeProps
 > = ({ inviteCode, ourPeer }) => {
-  const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [qrValue, setQrValue] = useState<string>('');

--- a/apps/router/src/guardian-ui/components/dashboard/danger/ScheduleShutdown.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/danger/ScheduleShutdown.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import {
   Text,
-  useTheme,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -13,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { useTranslation } from '@fedimint/utils';
 import { NumberFormControl } from '../../NumberFormControl';
+import { theme } from '../../../../../../../packages/ui/src/theme';
 
 interface ScheduleShutdownProps {
   latestSession: number;
@@ -21,7 +21,6 @@ interface ScheduleShutdownProps {
 export const ScheduleShutdown: React.FC<ScheduleShutdownProps> = ({
   latestSession,
 }) => {
-  const theme = useTheme();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);

--- a/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/EditMetaField.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/tabs/meta/manager/EditMetaField.tsx
@@ -7,13 +7,13 @@ import {
   IconButton,
   Input,
   Link,
-  useTheme,
 } from '@chakra-ui/react';
 import React from 'react';
 import { MetaFields } from '@fedimint/types';
 import { useTranslation, Trans } from '@fedimint/utils';
 import TrashIcon from '../../../../assets/svgs/trash.svg?react';
 import PlusIcon from '../../../../assets/svgs/plus.svg?react';
+import { theme } from '../../../../../../../../../packages/ui/src/theme';
 
 interface Props {
   metaFields: MetaFields;
@@ -27,7 +27,6 @@ export const EditMetaField: React.FC<Props> = ({
   protectDerivedMeta = true,
 }) => {
   const { t } = useTranslation();
-  const theme = useTheme();
 
   const derivedMetaKeys = ['federation_name'];
 

--- a/apps/router/src/guardian-ui/components/dashboard/tabs/status/GatewaysStatus.tsx
+++ b/apps/router/src/guardian-ui/components/dashboard/tabs/status/GatewaysStatus.tsx
@@ -8,7 +8,6 @@ import {
   Flex,
   Link,
   Text,
-  useTheme,
 } from '@chakra-ui/react';
 import { ClientConfig, Gateway, ModuleKind } from '@fedimint/types';
 import { Table, TableColumn, TableRow } from '@fedimint/ui';
@@ -16,6 +15,7 @@ import { useTranslation, formatEllipsized } from '@fedimint/utils';
 import InfoIcon from '../../../../assets/svgs/info.svg?react';
 import { useGuardianAdminApi } from '../../../../../hooks';
 import { ModuleRpc } from '../../../../../types/guardian';
+import { theme } from '../../../../../../../../packages/ui/src/theme';
 
 type TableKey = 'nodeId' | 'gatewayId' | 'fee';
 
@@ -24,7 +24,6 @@ interface GatewaysStatusProps {
 }
 
 export const GatewaysStatus: React.FC<GatewaysStatusProps> = ({ config }) => {
-  const theme = useTheme();
   const { t } = useTranslation();
   const api = useGuardianAdminApi();
   const [gateways, setGateways] = useState<Gateway[]>([]);

--- a/apps/router/src/guardian-ui/components/setup/RunDKG.tsx
+++ b/apps/router/src/guardian-ui/components/setup/RunDKG.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   Text,
   Flex,
-  useTheme,
 } from '@chakra-ui/react';
 import { GuardianServerStatus } from '@fedimint/types';
 import { useTranslation } from '@fedimint/utils';
@@ -16,6 +15,7 @@ import {
   useGuardianSetupApi,
   useGuardianSetupContext,
 } from '../../../hooks';
+import { theme } from '../../../../../../packages/ui/src/theme';
 
 interface Props {
   next(): void;
@@ -27,7 +27,6 @@ export const RunDKG: React.FC<Props> = ({ next }) => {
   const {
     state: { peers },
   } = useGuardianSetupContext();
-  const theme = useTheme();
   const [isWaitingForOthers, setIsWaitingForOthers] = useState(false);
   const [error, setError] = useState<string>();
   const ellipsis = useEllipsis();

--- a/apps/router/src/guardian-ui/components/setup/SetupProgress.tsx
+++ b/apps/router/src/guardian-ui/components/setup/SetupProgress.tsx
@@ -7,11 +7,11 @@ import {
   Progress,
   Show,
   Text,
-  useTheme,
 } from '@chakra-ui/react';
 import CheckIcon from '../../assets/svgs/white-check.svg?react';
 import { useTranslation } from '@fedimint/utils';
 import { StepState } from '../../../types/guardian';
+import { theme } from '../../../../../../packages/ui/src/theme';
 
 interface StepProps {
   text: string;
@@ -20,8 +20,6 @@ interface StepProps {
 }
 
 const Step: React.FC<StepProps> = ({ text, state, isFirst }) => {
-  const theme = useTheme();
-
   const colorState = (
     inActiveColor: string,
     activeColor: string,

--- a/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/BasicSettingsForm.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/BasicSettingsForm.tsx
@@ -6,7 +6,6 @@ import {
   Input,
   Button,
   Text,
-  useTheme,
   InputGroup,
   IconButton,
   InputRightAddon,
@@ -16,6 +15,7 @@ import { FormGroup } from '@fedimint/ui';
 import LightbulbLogo from '../../../../assets/svgs/lightbulb.svg?react';
 import { generatePassword } from '../../../../utils';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
+import { theme } from '../../../../../../../../packages/ui/src/theme';
 
 interface BasicSettingsFormProps {
   myName: string;
@@ -31,7 +31,6 @@ export const BasicSettingsForm: React.FC<BasicSettingsFormProps> = ({
   setPassword,
 }) => {
   const { t } = useTranslation();
-  const theme = useTheme();
   const [showPassword, setShowPassword] = useState(false);
 
   return (

--- a/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/SetConfiguration.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/setConfiguration/SetConfiguration.tsx
@@ -1,12 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Flex,
-  Icon,
-  Button,
-  Text,
-  useTheme,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Flex, Icon, Button, Text, useDisclosure } from '@chakra-ui/react';
 import {
   BitcoinRpc,
   ConfigGenParams,
@@ -31,6 +24,7 @@ import {
   useGuardianSetupApi,
   useGuardianSetupContext,
 } from '../../../../../hooks';
+import { theme } from '../../../../../../../../packages/ui/src/theme';
 
 interface Props {
   next: () => void;
@@ -51,7 +45,6 @@ export const SetConfiguration: React.FC<Props> = ({ next }: Props) => {
     },
     submitConfiguration,
   } = useGuardianSetupContext();
-  const theme = useTheme();
   const isHost = role === GuardianRole.Host;
   const isSolo = role === GuardianRole.Solo;
   const [myName, setMyName] = useState(stateMyName);

--- a/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
+++ b/apps/router/src/guardian-ui/components/setup/screens/verifyGuardians/VerifyGuardians.tsx
@@ -11,7 +11,6 @@ import {
   Spinner,
   Input,
   Tag,
-  useTheme,
   CircularProgress,
   Hide,
   Show,
@@ -42,6 +41,7 @@ import {
   useGuardianSetupContext,
   useTrimmedInputArray,
 } from '../../../../../hooks';
+import { theme } from '../../../../../../../../packages/ui/src/theme';
 
 interface PeerWithHash {
   id: string;
@@ -60,7 +60,6 @@ export const VerifyGuardians: React.FC<Props> = ({ next }) => {
     state: { role, numPeers, peers, ourCurrentId },
     toggleConsensusPolling,
   } = useGuardianSetupContext();
-  const theme = useTheme();
   const isHost = role === GuardianRole.Host;
   const [myHash, setMyHash] = useState('');
   const [peersWithHash, setPeersWithHash] = useState<PeerWithHash[]>();

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -30,6 +30,11 @@ module.exports = {
             message:
               "Please use <Flex direction='row|column'> instead as it does not add any additional styling, where as HStack/VStack components add 0.5 rem margin to their children, leading to inconsistent styling.",
           },
+          {
+            name: '@chakra-ui/react',
+            importNames: ['useTheme'],
+            message: 'Please import useTheme from @fedimint/ui instead.',
+          },
         ],
       },
     ],

--- a/packages/ui/src/CopyInput.tsx
+++ b/packages/ui/src/CopyInput.tsx
@@ -4,10 +4,10 @@ import {
   Input,
   Button,
   InputRightElement,
-  useTheme,
   useClipboard,
   Flex,
 } from '@chakra-ui/react';
+import { theme } from '../../../packages/ui/src/theme';
 
 export interface CopyInputProps {
   value: string;
@@ -21,7 +21,6 @@ export const CopyInput: React.FC<CopyInputProps> = ({
   buttonLeftIcon,
 }) => {
   const { onCopy, hasCopied } = useClipboard(value);
-  const theme = useTheme();
   const buttonWidth = {
     lg: '115px',
     md: '100px',

--- a/packages/ui/src/FormGroupHeading.tsx
+++ b/packages/ui/src/FormGroupHeading.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Icon, Heading, Spacer, useTheme, Button } from '@chakra-ui/react';
+import { Icon, Heading, Spacer, Button } from '@chakra-ui/react';
+import { theme } from './theme';
 
 interface Props {
   icon?: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
@@ -15,7 +16,6 @@ export const FormGroupHeading: React.FC<Props> = ({
   onClick,
   chevronIcon,
 }) => {
-  const theme = useTheme();
   return (
     <Button
       mb={3}

--- a/packages/ui/src/KeyValues.tsx
+++ b/packages/ui/src/KeyValues.tsx
@@ -1,5 +1,6 @@
-import { Flex, Text, useTheme } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 import React from 'react';
+import { theme } from './theme';
 
 interface KeyValue {
   key: string;
@@ -16,7 +17,6 @@ export const KeyValues: React.FC<KeyValuesProps> = ({
   keyValues,
   direction = 'column',
 }) => {
-  const theme = useTheme();
   return (
     <Flex
       direction={direction}

--- a/packages/ui/src/RadioButtonGroup.tsx
+++ b/packages/ui/src/RadioButtonGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Icon, Text, Flex, useTheme } from '@chakra-ui/react';
+import { Button, Icon, Text, Flex } from '@chakra-ui/react';
+import { theme } from '../../../packages/ui/src/theme';
 
 export interface RadioButtonOption<T extends string | number> {
   icon: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
@@ -21,7 +22,6 @@ export function RadioButtonGroup<T extends string | number>({
   onChange,
   activeIcon,
 }: RadioButtonGroupProps<T>): React.ReactElement {
-  const theme = useTheme();
   const defaultStyles = {
     background: theme.colors.white,
     borderColor: theme.colors.gray[200],

--- a/packages/ui/src/StatusIndicator.tsx
+++ b/packages/ui/src/StatusIndicator.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { Box, Text, useColorModeValue, useTheme } from '@chakra-ui/react';
+import { Box, Text, useColorModeValue } from '@chakra-ui/react';
+import { theme } from './theme';
 
 interface StatusIndicatorProps {
   status?: 'error' | 'warning' | 'success';
@@ -11,7 +12,6 @@ export const StatusIndicator: FC<StatusIndicatorProps> = ({
   status,
   children,
 }) => {
-  const theme = useTheme();
   const color = theme.colors[status || 'gray'];
   const bgColor = useColorModeValue(
     status ? color[50] : color[100],

--- a/packages/ui/src/Table.tsx
+++ b/packages/ui/src/Table.tsx
@@ -9,8 +9,8 @@ import {
   Tr,
   Td,
   Box,
-  useTheme,
 } from '@chakra-ui/react';
+import { theme } from '../../../packages/ui/src/theme';
 
 export interface TableColumn<T extends string> {
   key: T;
@@ -35,7 +35,6 @@ export function Table<T extends string>({
   columns,
   rows,
 }: TableProps<T>): React.ReactElement {
-  const theme = useTheme();
   const hasHeading = Boolean(title || description);
   const border = `1px solid ${theme.colors.border.table}`;
   return (


### PR DESCRIPTION
Fix: #162 
- Refactored the code to use theme from `packages/ui` 
- Added eslint rule to prevent future use of useTheme from `chakra-ui`