### PR TITLE
chore: add nix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ yarn dev
 
 For more advanced options and to learn how to spin up a Fedimint developer environment see here https://github.com/fedimint/fedimint/blob/master/HACKING.md and https://github.com/fedimint/fedimint/blob/master/docs/tutorial.md.
 
+In addition, see the [Nix Setup](docs/nix.md) guide for a step-by-step process to run the fedimint-ui development environment using Nix.
+
 ## Referencing Fedimint
 
 The docker containers and devimint are for specific releases or commits of `fedimint/fedimint`. At present, the reference commit-hash is `6da8ff595d1373e24f365d750872bd588fda17c9`

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -1,0 +1,16 @@
+# Nix Setup
+
+Here's the step-by-step process to run the fedimint-ui development environment using Nix. This is the recommended way to develop on the fedimint-ui if you don't already have fedimint infrastructure set up.
+
+1. Install Nix (if you haven't already)
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+2. In your terminal, `cd` to the fedimint-ui repo root directory
+3. Enter the following command to start Nix development environment
+   ```bash
+   nix develop
+   ```
+4. Run `yarn nix-guardian` or `yarn nix-gateway`
+
+> Note: **nix-gateway** preconfigures the federation so you don't have to go through federation setup. **nix-guardian** starts separate guardian nodes that are connected into the federation when you run through the federation setup process.


### PR DESCRIPTION
* I noticed some contributors are having trouble setting up the dev environment, as they don't have access to fedimint infrastructure and/or they're using WSL. The nix environment seems like the best option for them.
* The PR re-adds the nix setup instructions to the project.
